### PR TITLE
Use Open Dylan 2025.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ Dylan releases automatically. For example, the "v3" tag always points to the lat
 release with major version 3, e.g., `v3 -> v3.2.1`.  The major version of
 `install-opendylan` only changes when the Action itself is changed incompatibly, as with
 normal SemVer semantics.
+
+`v3` is currently the only moving tag.

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   tag:
     required: false
     type: string
-    default: v2024.1.0
+    default: v2025.1.0
 
 runs:
   using: composite


### PR DESCRIPTION
This change won't be picked up by users until a new release is made and the `v3` tag is pointed to it.